### PR TITLE
Render nytech ads in template

### DIFF
--- a/nytech_ads/templates/nytech-ads-template.php
+++ b/nytech_ads/templates/nytech-ads-template.php
@@ -1,0 +1,16 @@
+<?php
+/*
+Template Name: Nytech Ads Template
+*/
+
+get_header();
+?>
+
+    <div id="primary" class="content-area">
+        <main id="main" class="site-main">
+            <?php nytech_ads_plugin_render_content(); ?>
+        </main>
+    </div>
+
+<?php
+get_footer();


### PR DESCRIPTION
Some of the changes might not be necessary like the one on line 23.

Also in case it isn't clear I commented out //add_action('template_redirect', 'nytech_ads_plugin_render_content');
 to prevent it from showing up at the top of the page
 
 If it doesn't work right away you may need to deactivate / reactivate the plugin or change the template on the actual page. I was able to get it to work on a page like this:
 
 https://colewplistings.syworks.test/my-ads/?nytech_listing=1&remote_id=31